### PR TITLE
adds again fragmentId.as_bytes()

### DIFF
--- a/android/src/main/java/io/emurgo/chainlibs/ChainLibsModule.java
+++ b/android/src/main/java/io/emurgo/chainlibs/ChainLibsModule.java
@@ -638,6 +638,14 @@ public class ChainLibsModule extends ReactContextBaseJavaModule {
                 .pour(promise);
     }
 
+    @ReactMethod
+     public final void fragmentIdFromBytes(String bytes, Promise promise) {
+         Native.I
+                 .fragmentIdFromBytes(Base64.decode(bytes, Base64.DEFAULT))
+                 .map(RPtr::toJs)
+                 .pour(promise);
+     }
+
     // TransactionSignDataHash
 
     @ReactMethod

--- a/android/src/main/java/io/emurgo/chainlibs/Native.java
+++ b/android/src/main/java/io/emurgo/chainlibs/Native.java
@@ -134,6 +134,7 @@ final class Native {
     // FragmentId
     public final native Result<RPtr> fragmentIdCalculate(byte[] bytes);
     public final native Result<byte[]> fragmentIdAsBytes(RPtr fragmentId);
+    public final native Result<RPtr> fragmentIdFromBytes(byte[] bytes);
 
     // TransactionSignDataHash
     public final native Result<RPtr> transactionSignDataHashFromBytes(byte[] bytes);

--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ export class Outputs extends Ptr {
         const ret = await ChainLibs.outputsNew();
         return Ptr._wrap(ret, Outputs);
     }
-    
+
     /**
     * @returns {Promise<number>}
     */
@@ -517,6 +517,15 @@ export class FragmentId extends Ptr {
     async as_bytes() {
         const b64 = await ChainLibs.fragmentIdAsBytes(this.ptr);
         return Uint8ArrayFromB64(b64);
+    }
+
+    /**
+     * @param {Uint8Array} bytes
+     * @returns {Promise<FragmentId>}
+     */
+     static async from_bytes(bytes) {
+         const ret = await ChainLibs.fragmentIdFromBytes(b64FromUint8Array(bytes));
+         return Ptr._wrap(ret, FragmentId);
     }
 }
 
@@ -1415,7 +1424,7 @@ export class DelegationType extends Ptr {
         const ret = await ChainLibs.delegationTypeGetKind(this.ptr);
         return ret;
     }
-    
+
     /**
     * @returns {Promise<PoolId | undefined>}
     */

--- a/ios/ChainLibs.m
+++ b/ios/ChainLibs.m
@@ -859,6 +859,17 @@ RCT_EXPORT_METHOD(fragmentIdAsBytes:(nonnull NSString *)fragmentIdPtr withResolv
     }] exec:fragmentIdPtr andResolve:resolve orReject:reject];
 }
 
+RCT_EXPORT_METHOD(fragmentIdFromBytes:(nonnull NSString *)bytesStr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+ {
+     [[CSafeOperation new:^NSString*(NSString* bytesStr, CharPtr* error) {
+         RPtr result;
+         NSData* data = [NSData fromBase64:bytesStr];
+         return fragment_id_from_bytes((uint8_t*)data.bytes, data.length, &result, error)
+             ? [NSString stringFromPtr:result]
+             : nil;
+     }] exec:bytesStr andResolve:resolve orReject:reject];
+ }
+
 RCT_EXPORT_METHOD(transactionSignDataHashFromBytes:(nonnull NSString *)bytesStr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
 {
     [[CSafeOperation new:^NSString*(NSString* bytesStr, CharPtr* error) {

--- a/rust/src/android/fragment_id.rs
+++ b/rust/src/android/fragment_id.rs
@@ -37,3 +37,18 @@ pub unsafe extern "C" fn Java_io_emurgo_chainlibs_Native_fragmentIdAsBytes(
   })
   .jresult(&env)
 }
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_chainlibs_Native_fragmentIdFromBytes(
+  env: JNIEnv, _: JObject, bytes: jbyteArray
+) -> jobject {
+  handle_exception_result(|| {
+    env
+      .convert_byte_array(bytes)
+      .into_result()
+      .and_then(|bytes| FragmentId::from_bytes(&bytes).into_result())
+      .and_then(|fragment_id| fragment_id.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}

--- a/rust/src/ios/fragment_id.rs
+++ b/rust/src/ios/fragment_id.rs
@@ -24,3 +24,14 @@ pub unsafe extern "C" fn fragment_id_as_bytes(
   .map(|bytes| bytes.into())
   .response(result, error)
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn fragment_id_from_bytes(
+   data: *const u8, len: usize, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    FragmentId::from_bytes(std::slice::from_raw_parts(data, len)).into_result()
+  })
+  .map(|fragment_id| fragment_id.rptr())
+  .response(result, error)
+}


### PR DESCRIPTION
For some reason merging master in previous PR resulted in some changes being undone (basically all the code for `fragmentId.as_bytes()`.)

This PR reverts that merge.